### PR TITLE
Sorted frame queue

### DIFF
--- a/src/SortedFrameQueue.ts
+++ b/src/SortedFrameQueue.ts
@@ -1,0 +1,75 @@
+import Debug from 'debug';
+import { EventEmitter } from 'events';
+import { ScreencastFrame } from './VideoFrameBuilder';
+
+const debug = Debug('playwright-video:SortedFrameQueue');
+
+export class SortedFrameQueue extends EventEmitter {
+  // public for tests
+  public _frames = [];
+  private _size = 40;
+
+  constructor(size?: number) {
+    super();
+
+    if (size) {
+      this._size = size;
+    }
+  }
+
+  private _findInsertionIndex(timestamp: number): number {
+    if (this._frames.length === 0) {
+      return 0;
+    }
+
+    let i: number;
+    let frame: ScreencastFrame;
+
+    for (i = this._frames.length - 1; i >= 0; i--) {
+      frame = this._frames[i];
+
+      if (timestamp > frame.timestamp) {
+        break;
+      }
+    }
+
+    return i + 1;
+  }
+
+  private _emitFrames(frames: ScreencastFrame[]): void {
+    debug(`emitting ${frames.length} frames`);
+
+    this.emit('sortedframes', frames);
+  }
+
+  public insert(frame: ScreencastFrame): void {
+    debug(`inserting frame into queue: ${frame.timestamp}`);
+
+    // If the queue is already full, send half of the frames for processing first
+    if (this._frames.length === this._size) {
+      const numberOfFramesToSplice = Math.floor(this._size / 2);
+      const framesToProcess = this._frames.splice(0, numberOfFramesToSplice);
+
+      this._emitFrames(framesToProcess);
+    }
+
+    const insertionIndex = this._findInsertionIndex(frame.timestamp);
+
+    if (insertionIndex === this._frames.length) {
+      // If this frame is in order, push it
+      this._frames.push(frame);
+    } else {
+      // If this frame is out of order, splice it in
+      this._frames.splice(insertionIndex, 0, frame);
+    }
+  }
+
+  public drain(): void {
+    debug('draining queue');
+
+    // Send all remaining frames for processing
+    this._emitFrames(this._frames);
+
+    this._frames = [];
+  }
+}

--- a/src/VideoFrameBuilder.ts
+++ b/src/VideoFrameBuilder.ts
@@ -2,7 +2,7 @@ import Debug from 'debug';
 
 const debug = Debug('playwright-video:VideoFrameBuilder');
 
-interface ScreencastFrame {
+export interface ScreencastFrame {
   data: Buffer;
   received: number;
   timestamp: number;

--- a/src/VideoFrameBuilder.ts
+++ b/src/VideoFrameBuilder.ts
@@ -35,12 +35,6 @@ export class VideoFrameBuilder {
     }
 
     const frameCount = this._getFrameCount(screencastFrame);
-
-    if (frameCount < 0) {
-      debug('frames out of order: skipping frame');
-      return [];
-    }
-
     const frames = Array(frameCount).fill(this._previousFrame.data);
     debug(`returning ${frames.length} frames`);
 

--- a/tests/SortedFrameQueue.test.ts
+++ b/tests/SortedFrameQueue.test.ts
@@ -1,0 +1,130 @@
+import { SortedFrameQueue } from '../src/SortedFrameQueue';
+
+const buffer1 = Buffer.from('abc');
+const buffer2 = Buffer.from('def');
+const buffer3 = Buffer.from('ghi');
+const buffer4 = Buffer.from('jkl');
+const buffer5 = Buffer.from('mno');
+
+const screencastFrame1 = {
+  data: buffer1,
+  received: 1583187587500,
+  timestamp: 1583187587,
+};
+
+const screencastFrame2 = {
+  data: buffer2,
+  received: 1583187587600,
+  timestamp: 1583187588,
+};
+
+const screencastFrame3 = {
+  data: buffer3,
+  received: 1583187587700,
+  timestamp: 1583187589,
+};
+
+const screencastFrame4 = {
+  data: buffer4,
+  received: 1583187587800,
+  timestamp: 1583187590,
+};
+
+const screencastFrame5 = {
+  data: buffer5,
+  received: 1583187587900,
+  timestamp: 1583187591,
+};
+
+describe('SortedFrameQueue', () => {
+  it('inserts the first frame correctly', () => {
+    const frameQueue = new SortedFrameQueue();
+    frameQueue.insert(screencastFrame1);
+
+    expect(frameQueue._frames).toEqual([screencastFrame1]);
+  });
+
+  it('inserts correctly if frames are sent in order', () => {
+    const frameQueue = new SortedFrameQueue();
+    frameQueue.insert(screencastFrame1);
+    frameQueue.insert(screencastFrame2);
+    frameQueue.insert(screencastFrame3);
+
+    expect(frameQueue._frames).toEqual([
+      screencastFrame1,
+      screencastFrame2,
+      screencastFrame3,
+    ]);
+  });
+
+  it('inserts correctly if frames are sent out of order', () => {
+    const frameQueue = new SortedFrameQueue();
+    frameQueue.insert(screencastFrame1);
+    frameQueue.insert(screencastFrame3);
+    frameQueue.insert(screencastFrame2);
+
+    expect(frameQueue._frames).toEqual([
+      screencastFrame1,
+      screencastFrame2,
+      screencastFrame3,
+    ]);
+  });
+
+  it('emits half of the frames when the maximum size is reached', async () => {
+    const frameQueue = new SortedFrameQueue(4);
+    frameQueue.insert(screencastFrame1);
+    frameQueue.insert(screencastFrame2);
+    frameQueue.insert(screencastFrame4);
+    frameQueue.insert(screencastFrame3);
+
+    expect(frameQueue._frames).toEqual([
+      screencastFrame1,
+      screencastFrame2,
+      screencastFrame3,
+      screencastFrame4,
+    ]);
+
+    const framesPromise = new Promise((resolve) => {
+      frameQueue.once('sortedframes', (payload) => {
+        expect(payload).toEqual([screencastFrame1, screencastFrame2]);
+        resolve();
+      });
+    });
+
+    frameQueue.insert(screencastFrame5);
+
+    await framesPromise;
+
+    expect(frameQueue._frames).toEqual([
+      screencastFrame3,
+      screencastFrame4,
+      screencastFrame5,
+    ]);
+  });
+
+  it('emits all remaining frames when drained', async () => {
+    const frameQueue = new SortedFrameQueue(4);
+    frameQueue.insert(screencastFrame1);
+    frameQueue.insert(screencastFrame2);
+    frameQueue.insert(screencastFrame3);
+
+    const framesPromise = new Promise((resolve) => {
+      frameQueue.once('sortedframes', (payload) => {
+        expect(payload).toEqual([
+          screencastFrame1,
+          screencastFrame2,
+          screencastFrame3,
+          screencastFrame4,
+        ]);
+        resolve();
+      });
+    });
+
+    frameQueue.insert(screencastFrame4);
+    frameQueue.drain();
+
+    await framesPromise;
+
+    expect(frameQueue._frames).toEqual([]);
+  });
+});

--- a/tests/VideoFrameBuilder.test.ts
+++ b/tests/VideoFrameBuilder.test.ts
@@ -30,11 +30,4 @@ describe('VideoFrameBuilder', () => {
       Array(25).fill(buffer),
     );
   });
-
-  it('returns empty array if frames out of order', () => {
-    const frameBuilder = new VideoFrameBuilder();
-    frameBuilder.buildVideoFrames(screencastFrame2);
-
-    expect(frameBuilder.buildVideoFrames(screencastFrame)).toEqual([]);
-  });
 });


### PR DESCRIPTION
Hey team. I have here a fairly substantial refactor for your consideration. It introduces the concept of a frame queue (`SortedFrameQueue`). Frames are sorted as they're inserted into the queue. When the queue is full, half of the frames are emitted for processing. When we're done working with the queue, we can drain the remaining frames. The purpose of this change is as follows:

* This allows us to preserve frames that are sent out of order from CDP instead of discarding them
* This paves the way for further improvements that I'd like to make
  - Clean up the "stop" logic in `ScreencastFrameCollector` (make sure we have all the frames without sleeping longer than necessary)
  - Provide the option to follow page focus (capture video of popups that may open)
