### PR TITLE
Clean up stopping

### DIFF
--- a/src/PageVideoCapture.ts
+++ b/src/PageVideoCapture.ts
@@ -83,13 +83,12 @@ export class PageVideoCapture {
     this._previousFrame = currentFrame;
   }
 
-  private _writeFinalFrame(): void {
+  private _writeFinalFrameUpToTimestamp(stoppedTimestamp: number): void {
     if (!this._previousFrame) return;
 
-    // write the final frame based on the duration between it and now
+    // write the final frame based on the duration between it and when the screencast was stopped
     debug('write final frame');
-    const durationSeconds =
-      (Date.now() - this._previousFrame.timestamp * 1000) / 1000;
+    const durationSeconds = stoppedTimestamp - this._previousFrame.timestamp;
     this._writer.write(this._previousFrame.data, durationSeconds);
   }
 
@@ -99,9 +98,9 @@ export class PageVideoCapture {
     debug('stop');
     this._stopped = true;
 
-    await this._collector.stop();
+    const stoppedTimestamp = await this._collector.stop();
     this._queue.drain();
-    this._writeFinalFrame();
+    this._writeFinalFrameUpToTimestamp(stoppedTimestamp);
 
     return this._writer.stop();
   }

--- a/src/ScreencastFrameCollector.ts
+++ b/src/ScreencastFrameCollector.ts
@@ -93,7 +93,13 @@ export class ScreencastFrameCollector extends EventEmitter {
 
     this._stoppedTimestamp = Date.now() / 1000;
     debug(`stopping screencast at ${this._stoppedTimestamp}`);
-    await this._endedPromise;
+
+    // Make sure stopping takes no longer than 1s in cases when the screencast API
+    // doesn't emit frames all the way up to the stopped timestamp.
+    await Promise.race([
+      this._endedPromise,
+      new Promise((resolve) => setTimeout(resolve, 1000)),
+    ]);
 
     try {
       debug('detaching client');

--- a/src/ScreencastFrameCollector.ts
+++ b/src/ScreencastFrameCollector.ts
@@ -26,7 +26,7 @@ export class ScreencastFrameCollector extends EventEmitter {
   // public for tests
   public _client: CDPSession;
   private _page: Page;
-  private _stopped = false;
+  private _stoppedTimestamp;
 
   protected constructor(page: Page) {
     super();
@@ -75,11 +75,15 @@ export class ScreencastFrameCollector extends EventEmitter {
     });
   }
 
-  public async stop(): Promise<void> {
-    if (this._stopped) return;
+  public async stop(): Promise<number> {
+    if (this._stoppedTimestamp) {
+      throw new Error(
+        'pw-video: Cannot call stop twice on the same capture.',
+      );
+    }
 
-    debug('stopping');
-    this._stopped = true;
+    this._stoppedTimestamp = Date.now() / 1000;
+    debug(`stopping screencast at ${this._stoppedTimestamp}`);
 
     // Screencast API takes time to send frames
     // Wait 1s for frames to arrive
@@ -94,5 +98,7 @@ export class ScreencastFrameCollector extends EventEmitter {
     }
 
     debug('stopped');
+
+    return this._stoppedTimestamp;
   }
 }

--- a/src/ScreencastFrameCollector.ts
+++ b/src/ScreencastFrameCollector.ts
@@ -26,7 +26,8 @@ export class ScreencastFrameCollector extends EventEmitter {
   // public for tests
   public _client: CDPSession;
   private _page: Page;
-  private _stoppedTimestamp;
+  private _stoppedTimestamp: number;
+  private _endedPromise: Promise<void>;
 
   protected constructor(page: Page) {
     super();
@@ -39,31 +40,39 @@ export class ScreencastFrameCollector extends EventEmitter {
   }
 
   private _listenForFrames(): void {
-    this._client.on('Page.screencastFrame', async (payload) => {
-      debug(`received frame with timestamp ${payload.metadata.timestamp}`);
+    this._endedPromise = new Promise((resolve) => {
+      this._client.on('Page.screencastFrame', async (payload) => {
+        if (!payload.metadata.timestamp) {
+          debug('skipping frame without timestamp');
+          return;
+        }
 
-      const ackPromise = this._client.send('Page.screencastFrameAck', {
-        sessionId: payload.sessionId,
+        if (this._stoppedTimestamp && payload.metadata.timestamp > this._stoppedTimestamp) {
+          debug('all frames received');
+          resolve();
+          return;
+        }
+
+        debug(`received frame with timestamp ${payload.metadata.timestamp}`);
+
+        const ackPromise = this._client.send('Page.screencastFrameAck', {
+          sessionId: payload.sessionId,
+        });
+
+        this.emit('screencastframe', {
+          data: Buffer.from(payload.data, 'base64'),
+          received: Date.now(),
+          timestamp: payload.metadata.timestamp,
+        });
+
+        try {
+          // capture error so it does not propagate to the user
+          // most likely it is due to the page closing
+          await ackPromise;
+        } catch (e) {
+          debug('error sending screencastFrameAck %j', e.message);
+        }
       });
-
-      if (!payload.metadata.timestamp) {
-        debug('skip frame without timestamp');
-        return;
-      }
-
-      this.emit('screencastframe', {
-        data: Buffer.from(payload.data, 'base64'),
-        received: Date.now(),
-        timestamp: payload.metadata.timestamp,
-      });
-
-      try {
-        // capture error so it does not propagate to the user
-        // most likely it is due to the page closing
-        await ackPromise;
-      } catch (e) {
-        debug('error sending screencastFrameAck %j', e.message);
-      }
     });
   }
 
@@ -84,11 +93,7 @@ export class ScreencastFrameCollector extends EventEmitter {
 
     this._stoppedTimestamp = Date.now() / 1000;
     debug(`stopping screencast at ${this._stoppedTimestamp}`);
-
-    // Screencast API takes time to send frames
-    // Wait 1s for frames to arrive
-    // TODO figure out a better pattern for this
-    await new Promise((resolve) => setTimeout(resolve, 1000));
+    await this._endedPromise;
 
     try {
       debug('detaching client');


### PR DESCRIPTION
Hi team. Thanks for all your reviews and letting me contribute to this project. Hope you're both staying safe and healthy.

Here's a PR that cleans up stopping in `ScreencastFrameCollector`.

* No more fixed 1s wait for frames to arrive - instead we mark when `stop()` is called and wait for frame timestamps to surpass that timestamp
* No more extra frames stuffed at the end of the recording - the video capture will stop as soon as `stop()` is called
